### PR TITLE
Enable passing ios.presentationStyle options with Vue

### DIFF
--- a/src/vue-windowed-modal.ts
+++ b/src/vue-windowed-modal.ts
@@ -33,7 +33,8 @@ const VueWindowedModal = {
                 fullscreen: false,
                 animated: true,
                 stretched: false,
-                dimAmount: 0.5
+                dimAmount: 0.5,
+                ios: {},
             };
             // build options object with defaults
             options = { ...defaultOptions, ...options };
@@ -66,7 +67,8 @@ const VueWindowedModal = {
                     fullscreen: options.fullscreen,
                     animated: options.animated,
                     stretched: options.stretched,
-                    dimAmount: options.dimAmount
+                    dimAmount: options.dimAmount,
+                    ios: options.ios,
                 });
             });
         };

--- a/src/vue-windowed-modal.ts
+++ b/src/vue-windowed-modal.ts
@@ -34,7 +34,7 @@ const VueWindowedModal = {
                 animated: true,
                 stretched: false,
                 dimAmount: 0.5,
-                ios: {},
+                ios: {}
             };
             // build options object with defaults
             options = { ...defaultOptions, ...options };
@@ -68,7 +68,7 @@ const VueWindowedModal = {
                     animated: options.animated,
                     stretched: options.stretched,
                     dimAmount: options.dimAmount,
-                    ios: options.ios,
+                    ios: options.ios
                 });
             });
         };


### PR DESCRIPTION
## What is the current behavior?
Passing `ios: { presentationStyle: 5 }` has no effect with Nativescript-Vue.

## What is the new behavior?
Option is now passed and the user can alter the iOS [UIModalPresentationStyle](UIModalPresentationStyle) property.
