### PR TITLE
fix(android) update namespaces to AndroidX, making the plugin work with NativeScript 6

### DIFF
--- a/src/windowed-modal.common.ts
+++ b/src/windowed-modal.common.ts
@@ -161,7 +161,7 @@ function androidModal(parent: any, options: ExtendedShowModalOptions) {
             }
         }
 
-        class CustomDialogFragmentImpl extends android.support.v4.app.DialogFragment {
+        class CustomDialogFragmentImpl extends androidx.fragment.app.DialogFragment {
 
             owner: any;
             private _fullscreen: boolean;
@@ -189,7 +189,7 @@ function androidModal(parent: any, options: ExtendedShowModalOptions) {
                 this._shownCallback = customDialogOptions.shownCallback;
                 this.owner._dialogFragment = this;
 
-                this.setStyle(android.support.v4.app.DialogFragment.STYLE_NO_TITLE, 0);
+                this.setStyle(androidx.fragment.app.DialogFragment.STYLE_NO_TITLE, 0);
 
                 const dialog = new CustomDialogImpl(this, this.getActivity(), this.getTheme());
 


### PR DESCRIPTION
Signed-off-by: Till Sanders <till.sanders@finanzritter.com>

## What is the current behavior?
Using the plugin with {N} 6.0.0 results in the following error message:

```
TypeError: Cannot read property 'extend' of undefined↵    at __extends (/data/data/org.nativescript.mobileapp/files/internal/ts_helpers.js:51:36)↵    at file:///data/data/org.nativescript.mobileapp/files/app/vendor.js:51703:7↵    at initializeDialogFragment (file:///data/data/org.nativescript.mobileapp/files/app/vendor.js:51799:6)↵    at ModalStack.androidModal [as _showNativeModalView] (file:///data/data/org.nativescript.mobileapp/files/app/vendor.js:51804:3)↵    at AbsoluteLayout.ViewCommon.showModal (file:///data/data/org.nativescript.mobileapp/files/app/vendor.js:72972:10)↵    at file:///data/data/org.nativescript.mobileapp/files/app/vendor.js:51530:30↵    at new Promise (<anonymous>)↵    at VueComponent.Vue.$showModal (file:///data/data/org.nativescript.mobileapp/files/app/vendor.js:51501:14)↵    at VueComponent.addReceipt (file:///data/data/org.nativescript.mobileapp/files/app/bundle.js:1488:12)↵    at tap (file:///data/data/org.nativescript.mobileapp/files/app/bundle.js:3054:21)
```

## What is the new behavior?
It works with {N} 6.0.0.

BREAKING CHANGES:
I'm not sure, whether this broke compatibility with older Android versions. I'm not much of an Android expert!